### PR TITLE
Fixes bug in CI where charmcraft was not available to publish the lib

### DIFF
--- a/.github/workflows/publish-lib.yaml
+++ b/.github/workflows/publish-lib.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     name: Charmhub upload orc8r-libs
     steps:
-      - uses: actions/checkout@v3
-      - name: Select Charmhub channel
-        uses: canonical/charming-actions/channel@2.2.5
-        id: channel
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
       - name: Publish NRF lib
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"


### PR DESCRIPTION
# Description

Fixes bug in CI where charmcraft was not available to publish the lib

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
