### PR TITLE
Adds pytest-interaface-tester back to required deps

### DIFF
--- a/lib/charms/sdcore_nrf/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf/v0/fiveg_nrf.py
@@ -41,7 +41,7 @@ class DummyFiveGNRFRequirerCharm(CharmBase):
         self.framework.observe(self.nrf_requirer.on.nrf_available, self._on_nrf_available)
 
     def _on_nrf_available(self, event: NRFAvailableEvent):
-        nrf_url = event.url
+        nrf_url = self.nrf_requirer.nrf_url
         <do something with the nrf_url>
 
 
@@ -110,10 +110,10 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = [
-    "pydantic",
+    "pydantic", "pytest-interface-tester"
 ]
 
 

--- a/lib/charms/sdcore_nrf/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf/v0/fiveg_nrf.py
@@ -112,9 +112,7 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 3
 
-PYDEPS = [
-    "pydantic", "pytest-interface-tester"
-]
+PYDEPS = ["pydantic", "pytest-interface-tester"]
 
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jinja2
 lightkube
 lightkube-models
 pydantic
+pytest-interface-tester

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,3 @@ pytest-operator
 types-PyYAML
 types-setuptools
 types-toml
-pytest-interface-tester


### PR DESCRIPTION
# Description

Fixes requirer docs and adds `pytest-interface-tester` as required dependency.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
