### PR TITLE
[Bug fix] Support for providing the NRF url to multiple requirers

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -169,7 +169,7 @@ class NRFOperatorCharm(CharmBase):
         Returns:
             bool: Whether the relation was created.
         """
-        return bool(self.model.get_relation(relation_name))
+        return len(self.model.relations[relation_name]) >= 1
 
     @property
     def _pebble_layer(self) -> Layer:

--- a/src/charm.py
+++ b/src/charm.py
@@ -169,7 +169,7 @@ class NRFOperatorCharm(CharmBase):
         Returns:
             bool: Whether the relation was created.
         """
-        return len(self.model.relations[relation_name]) >= 1
+        return bool(self.model.relations[relation_name])
 
     @property
     def _pebble_layer(self) -> Layer:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -207,25 +207,32 @@ class TestCharm(unittest.TestCase):
     def test_service_starts_running_after_nrf_relation_joined_when_fiveg_pebble_ready_then_nrf_url_is_in_relation_databag(  # noqa: E501
         self, patch_exists
     ):
+        patch_exists.return_value = True
         self.harness.set_can_connect(container="nrf", val=True)
         self.harness.set_leader(is_leader=True)
-        relation_id = self.harness.add_relation(
+        relation_1_id = self.harness.add_relation(
             relation_name="fiveg-nrf",
-            remote_app="nrf-requirer",
+            remote_app="nrf-requirer-1",
         )
-        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="nrf-requirer/0")
-        relation_data = self.harness.get_relation_data(
-            relation_id=relation_id, app_or_unit=self.harness.charm.app.name
+        relation_2_id = self.harness.add_relation(
+            relation_name="fiveg-nrf",
+            remote_app="nrf-requirer-2",
         )
-        self.assertEqual(relation_data, {})
-
-        patch_exists.return_value = True
-
+        self.harness.add_relation_unit(
+            relation_id=relation_1_id, remote_unit_name="nrf-requirer-1/0"
+        )
+        self.harness.add_relation_unit(
+            relation_id=relation_2_id, remote_unit_name="nrf-requirer-2/0"
+        )
         self.create_database_relation()
 
         self.harness.container_pebble_ready("nrf")
 
-        relation_data = self.harness.get_relation_data(
-            relation_id=relation_id, app_or_unit=self.harness.charm.app.name
+        relation_1_data = self.harness.get_relation_data(
+            relation_id=relation_1_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["url"], "http://nrf:29510")
+        relation_2_data = self.harness.get_relation_data(
+            relation_id=relation_2_id, app_or_unit=self.harness.charm.app.name
+        )
+        self.assertEqual(relation_1_data["url"], "http://nrf:29510")
+        self.assertEqual(relation_2_data["url"], "http://nrf:29510")


### PR DESCRIPTION
# Description

Support for providing nrf url even when multiple requirers. Before applying this fix, the NRF use to produce this log when related to multiple charms:

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-nrf-0/charm/./src/charm.py", line 227, in <module>
    main(NRFOperatorCharm)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/main.py", line 441, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/main.py", line 149, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/framework.py", line 354, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/framework.py", line 830, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/framework.py", line 919, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-nrf-0/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 929, in _on_relation_changed_event
    self.on.database_created.emit(event.relation, app=event.app, unit=event.unit)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/framework.py", line 354, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/framework.py", line 830, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/framework.py", line 919, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-nrf-0/charm/./src/charm.py", line 73, in _on_database_created
    self._configure_pebble_layer(event)
  File "/var/lib/juju/agents/unit-nrf-0/charm/./src/charm.py", line 111, in _configure_pebble_layer
    self._publish_nrf_info_for_all_requirers(NRF_URL)
  File "/var/lib/juju/agents/unit-nrf-0/charm/./src/charm.py", line 137, in _publish_nrf_info_for_all_requirers
    if not self._relation_created(NRF_RELATION_NAME):
  File "/var/lib/juju/agents/unit-nrf-0/charm/./src/charm.py", line 172, in _relation_created
    return bool(self.model.get_relation(relation_name))
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/model.py", line 249, in get_relation
    return self.relations._get_unique(relation_name, relation_id)
  File "/var/lib/juju/agents/unit-nrf-0/charm/venv/ops/model.py", line 769, in _get_unique
    raise TooManyRelatedAppsError(relation_name, num_related, 1)
ops.model.TooManyRelatedAppsError: Too many remote applications on fiveg-nrf (5 > 1)
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
