### PR TITLE
[Bug fix] Reduces log level for invalid relation data

### DIFF
--- a/lib/charms/sdcore_nrf/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf/v0/fiveg_nrf.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -158,7 +158,7 @@ def data_matches_provider_schema(data: dict) -> bool:
         ProviderSchema(app=data)
         return True
     except ValidationError as e:
-        logger.error("Invalid data: %s", e)
+        logger.debug("Invalid data: %s", e)
         return False
 
 
@@ -239,7 +239,7 @@ class NRFRequires(Object):
             return None
         remote_app_relation_data = dict(relation.data[relation.app])
         if not data_matches_provider_schema(remote_app_relation_data):
-            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            logger.debug("Invalid relation data: %s", remote_app_relation_data)
             return None
         return remote_app_relation_data
 

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
@@ -79,12 +79,12 @@ class TestFiveGNRFRequirer(unittest.TestCase):
         relation_id = self._create_relation(remote_app_name=self.remote_app_name)
         relation_data = {"pizza": "steak"}
 
-        with self.assertLogs() as log:
+        with self.assertLogs(level="DEBUG") as log:
             self.harness.update_relation_data(
                 relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
             )
             self.assertIn(
-                f"ERROR:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
+                f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
                 log.output,
             )
 
@@ -109,14 +109,14 @@ class TestFiveGNRFRequirer(unittest.TestCase):
         relation_id = self._create_relation(remote_app_name=self.remote_app_name)
         relation_data = {}
 
-        with self.assertLogs() as log:
+        with self.assertLogs(level="DEBUG") as log:
             self.harness.update_relation_data(
                 relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
             )
             nrf_url = self.harness.charm.nrf_requirer.nrf_url
             self.assertIsNone(nrf_url)
             self.assertIn(
-                f"ERROR:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
+                f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
                 log.output,
             )
 
@@ -126,13 +126,13 @@ class TestFiveGNRFRequirer(unittest.TestCase):
         relation_id = self._create_relation(remote_app_name=self.remote_app_name)
         relation_data = {"pizza": "steak"}
 
-        with self.assertLogs() as log:
+        with self.assertLogs(level="DEBUG") as log:
             self.harness.update_relation_data(
                 relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
             )
             nrf_url = self.harness.charm.nrf_requirer.nrf_url
             self.assertIsNone(nrf_url)
             self.assertIn(
-                f"ERROR:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
+                f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
                 log.output,
             )


### PR DESCRIPTION
# Description

Reduces log level for invalid relation data. The logs were filled with these types of logs when deploying sdcore:
```
unit-nssf-0: 10:19:07 ERROR unit.nssf/0.juju-log fiveg_nrf:6: Invalid data: 1 validation error for ProviderSchema
app -> url
  field required (type=value_error.missing)
unit-nssf-0: 10:19:07 ERROR unit.nssf/0.juju-log fiveg_nrf:6: Invalid relation data: {}
```

When the relation is created, it's normal for the relation data not to be valid, those are not errors.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
