### PR TITLE
[Feat] Uses ROCK instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ juju relate sdcore-nrf:database mongodb-k8s
 
 # Image
 
-- **nrf**: `omecproject/5gc-nrf:master-b747b98`
+- **nrf**: `ghcr.io/canonical/sdcore-nrf:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   nrf-image:
     type: oci-image
     description: OCI image for SD-Core nrf
-    upstream-source: omecproject/5gc-nrf:master-b747b98
+    upstream-source: ghcr.io/canonical/sdcore-nrf:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -266,7 +266,7 @@ class NRFOperatorCharm(CharmBase):
                     "nrf": {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/free5gc/nrf/nrf --nrfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",  # noqa: E501
+                        "command": f"/bin/nrf --nrfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}",  # noqa: E501
                         "environment": self._environment_variables,
                     },
                 },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-tests/unit/test_charm.py# Copyright 2023 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import unittest

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+tests/unit/test_charm.py# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import unittest
@@ -178,7 +178,7 @@ class TestCharm(unittest.TestCase):
             "services": {
                 "nrf": {
                     "override": "replace",
-                    "command": "/free5gc/nrf/nrf --nrfcfg /etc/nrf/nrfcfg.yaml",
+                    "command": "/bin/nrf --nrfcfg /etc/nrf/nrfcfg.yaml",
                     "startup": "enabled",
                     "environment": {
                         "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",


### PR DESCRIPTION
# Description

Uses ROCK instead of upstream image

 Don't merge before the [ROCK](https://github.com/canonical/sdcore-nrf-rock/pull/1) is merged.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
