### PR TITLE
Adding support for relation-broken event

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Charmed Operator for the SD-Core Network Repository Function (NRF).
 ```bash
 juju deploy sdcore-nrf --trust --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju relate sdcore-nrf:database mongodb-k8s
+juju integrate sdcore-nrf:database mongodb-k8s
 ```
 
 # Image

--- a/tests/unit/charms/sdcore_nrf/v0/dummy_requirer_charm/src/dummy_requirer_charm.py
+++ b/tests/unit/charms/sdcore_nrf/v0/dummy_requirer_charm/src/dummy_requirer_charm.py
@@ -10,7 +10,7 @@ import logging
 from ops.charm import CharmBase
 from ops.main import main
 
-from lib.charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from lib.charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFBrokenEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +23,14 @@ class DummyFiveGNRFRequirerCharm(CharmBase):
         super().__init__(*args)
         self.nrf_requirer = NRFRequires(self, "fiveg-nrf")
         self.framework.observe(self.nrf_requirer.on.nrf_available, self._on_nrf_available)
+        self.framework.observe(self.nrf_requirer.on.nrf_broken, self._on_nrf_broken)
 
     def _on_nrf_available(self, event: NRFAvailableEvent):
         logging.info(f"NRF URL from the event: {event.url}")
         logging.info(f"NRF URL from the property: {self.nrf_requirer.nrf_url}")
+
+    def _on_nrf_broken(self, event: NRFBrokenEvent) -> None:
+        logging.info(f"Received {event}")
 
 
 if __name__ == "__main__":

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
@@ -1,8 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+import logging
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from ops import testing
 
@@ -16,7 +16,7 @@ DUMMY_REQUIRER_CHARM = "tests.unit.charms.sdcore_nrf.v0.dummy_requirer_charm.src
 class TestFiveGNRFRequirer(unittest.TestCase):
     def setUp(self):
         self.relation_name = "fiveg-nrf"
-        self.remote_app_name = "dummy-nrf-requirer"
+        self.remote_app_name = "dummy-nrf-provider"
         self.remote_unit_name = f"{self.remote_app_name}/0"
         self.harness = testing.Harness(DummyFiveGNRFRequirerCharm)
         self.addCleanup(self.harness.cleanup)
@@ -136,3 +136,14 @@ class TestFiveGNRFRequirer(unittest.TestCase):
                 f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
                 log.output,
             )
+
+    @patch("lib.charms.sdcore_nrf.v0.fiveg_nrf.NRFRequirerCharmEvents.nrf_broken")
+    def test_given_nrf_relation_created_when_relation_broken_then_nrf_broken_event_emitted(
+        self, patched_nrf_broken_event
+    ):
+        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+
+        self.harness.remove_relation(relation_id)
+
+        calls = [call.emit()]
+        patched_nrf_broken_event.assert_has_calls(calls)

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-import logging
+
 import unittest
 from unittest.mock import call, patch
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ allowlist_externals = /usr/bin/env
 [testenv:unit]
 description = Run unit tests
 commands =
-    coverage run --source={[vars]src_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
+    coverage run --source={[vars]src_path},{[vars]lib_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
 
 [testenv:integration]


### PR DESCRIPTION
# Description

- Adds new, custom `nrf_broken` event to enable support for `relation-broken` in SD-Core charms

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
