### PR TITLE
Adds renovate rule to scan tox.ini

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 6 * * 0'
+    - cron: '40 6 * * 0'
 
 jobs:
   check-libraries:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "pip_requirements": {
+    "fileMatch": [
+      "^tox.ini$"
+    ]
+  }
 }


### PR DESCRIPTION
# Description

Adds a rule to the Renovate configuration to scan tox.ini dependencies.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
