### PR TITLE
(FIX) Downgrading ops to 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops
+ops==2.4.1
 jinja2
 lightkube
 lightkube-models


### PR DESCRIPTION
# Description

Latest `ops` is incompatible with `scenario`. Due to this, integration and unit tests fail.
This PR pins `ops` version to the last compatible one, which is `2.4.1`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
