### PR TITLE
Enforce TLS Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Charmed Operator for the SD-Core Network Repository Function (NRF).
 ```bash
 juju deploy sdcore-nrf --trust --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju deploy self-signed-certificates
+juju deploy self-signed-certificates --channel=beta
 
 juju integrate sdcore-nrf:database mongodb-k8s
 juju integrate self-signed-certificates:certificates sdcore-nrf:certificates

--- a/README.md
+++ b/README.md
@@ -19,13 +19,9 @@ Charmed Operator for the SD-Core Network Repository Function (NRF).
 ```bash
 juju deploy sdcore-nrf --trust --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
-juju integrate sdcore-nrf:database mongodb-k8s
-```
-
-## Optional
-
-```bash
 juju deploy self-signed-certificates
+
+juju integrate sdcore-nrf:database mongodb-k8s
 juju integrate self-signed-certificates:certificates sdcore-nrf:certificates
 ```
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -73,3 +73,23 @@ async def test_given_charm_is_deployed_when_relate_to_mongo_and_certificates_the
         relation1=f"{APP_NAME}:certificates", relation2=f"{TLS_APPLICATION_NAME}:certificates"
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_tls_and_wait_for_blocked_status(ops_test, build_and_deploy):
+    await ops_test.model.remove_application(TLS_APPLICATION_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_tls_and_wait_for_active_status(ops_test, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_APPLICATION_NAME,
+        application_name=TLS_APPLICATION_NAME,
+        channel="edge",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=APP_NAME, relation2=TLS_APPLICATION_NAME
+    )
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -31,7 +31,7 @@ async def deploy_self_signed_certificates(ops_test):
     await ops_test.model.deploy(
         TLS_APPLICATION_NAME,
         application_name=TLS_APPLICATION_NAME,
-        channel="edge",
+        channel="beta",
     )
 
 
@@ -86,7 +86,7 @@ async def test_restore_tls_and_wait_for_active_status(ops_test, build_and_deploy
     await ops_test.model.deploy(  # type: ignore[union-attr]
         TLS_APPLICATION_NAME,
         application_name=TLS_APPLICATION_NAME,
-        channel="edge",
+        channel="beta",
         trust=True,
     )
     await ops_test.model.add_relation(  # type: ignore[union-attr]

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -11,7 +11,7 @@ configuration:
     bindingIPv4: 0.0.0.0
     port: 29510
     registerIPv4: 1.1.1.1
-    scheme: http
+    scheme: https
   serviceNameList:
   - nnrf-nfm
   - nnrf-disc


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the `certificates` relation is created, and in waiting status until a certificate is stored.



# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
