### PR TITLE
Set units to blocked status when scaling beyond 1

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -173,14 +173,14 @@ class NRFOperatorCharm(CharmBase):
         self._publish_nrf_info_for_all_requirers()
         self.unit.status = ActiveStatus()
 
-    def _on_certificates_relation_created(self, event: RelationCreatedEvent) -> None:
+    def _on_certificates_relation_created(self, event: EventBase) -> None:
         """Generates Private key."""
         if not self._container.can_connect():
             event.defer()
             return
         self._generate_private_key()
 
-    def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
+    def _on_certificates_relation_broken(self, event: EventBase) -> None:
         """Deletes TLS related artifacts and reconfigures workload."""
         if not self._container.can_connect():
             event.defer()
@@ -190,7 +190,7 @@ class NRFOperatorCharm(CharmBase):
         self._delete_certificate()
         self.unit.status = BlockedStatus("Waiting for certificates relation to be created")
 
-    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+    def _on_certificates_relation_joined(self, event: EventBase) -> None:
         """Generates CSR and requests new certificate."""
         if not self._container.can_connect():
             event.defer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,6 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
 )
 from jinja2 import Environment, FileSystemLoader  # type: ignore[import]
 from lightkube.models.core_v1 import ServicePort
-from ops import RelationBrokenEvent, RelationCreatedEvent
 from ops.charm import CharmBase, EventBase, RelationJoinedEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, ModelError, WaitingStatus

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,11 +3,13 @@
 # See LICENSE file for licensing details.
 
 
+from collections import Counter
 import logging
 from pathlib import Path
 
 import pytest
 import yaml
+from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -94,3 +96,21 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
     )
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_APPLICATION_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+async def test_when_scale_nrf_beyond_1_then_only_one_unit_is_active(
+    ops_test: OpsTest, build_and_deploy
+):
+    assert ops_test.model
+    assert isinstance(app := ops_test.model.applications[APP_NAME], Application)
+    await app.scale(3)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000)
+    unit_statuses = Counter(unit.workload_status for unit in app.units)
+    assert unit_statuses.get("active") == 1
+    assert unit_statuses.get("blocked") == 2
+
+
+async def test_remove_nrf(ops_test: OpsTest, build_and_deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(APP_NAME, block_until_done=True)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,8 +3,8 @@
 # See LICENSE file for licensing details.
 
 
-from collections import Counter
 import logging
+from collections import Counter
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
# Description

Instead of throwing an error, block the units when scaled beyond 1.

Throwing an error causes the charm to go into a bad state, where it can't even be removed without manual intervention. This even causes an issue with a single unit, as sometimes leader status is removed before the charm has finished processing all events.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
