### PR TITLE
fix: go into blocked status when database relation is removed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -113,6 +113,7 @@ class NRFOperatorCharm(CharmBase):
             ],
         )
         self.framework.observe(self.on.database_relation_joined, self._configure_nrf)
+        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self.on.nrf_pebble_ready, self._configure_nrf)
         self.framework.observe(self._database.on.database_created, self._configure_nrf)
         self.framework.observe(
@@ -225,6 +226,14 @@ class NRFOperatorCharm(CharmBase):
             logger.debug("Expiring certificate is not the one stored")
             return
         self._request_new_certificate()
+
+    def _on_database_relation_broken(self, event: EventBase) -> None:
+        """Event handler for database relation broken.
+
+        Args:
+            event: Juju event
+        """
+        self.unit.status = BlockedStatus("Waiting for database relation")
 
     def _generate_private_key(self) -> None:
         """Generates and stores private key."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,8 +44,12 @@ class TestCharm(unittest.TestCase):
         )
         return relation_id
 
-    def _database_is_available(self) -> int:
-        """Create a database relation and set the database information."""
+    def _create_database_relation_and_populate_data(self) -> int:
+        """Create a database relation and set the database information.
+
+        Returns:
+            relation_id: ID of the created relation
+        """
         database_relation_id = self._create_database_relation()
         self.harness.update_relation_data(
             relation_id=database_relation_id,
@@ -107,7 +111,7 @@ class TestCharm(unittest.TestCase):
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
         patch_exists.return_value = True
-        database_relation_id = self._database_is_available()
+        database_relation_id = self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
 
@@ -146,7 +150,7 @@ class TestCharm(unittest.TestCase):
     def test_given_storage_not_attached_when_pebble_ready_then_status_is_waiting(
         self,
     ):
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
         self.assertEqual(
@@ -170,7 +174,7 @@ class TestCharm(unittest.TestCase):
         patch_check_output.return_value = b"1.1.1.1"
         patch_exists.side_effect = [True, False, True, False]
         self.harness.set_can_connect(container="nrf", val=True)
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready("nrf")
         self.assertEqual(
@@ -201,7 +205,7 @@ class TestCharm(unittest.TestCase):
         event.certificate_signing_request = csr
         patch_pull.side_effect = [StringIO(csr), StringIO("Dummy Content")]
         patch_exists.side_effect = [True, True, False, False]
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.charm._on_certificate_available(event=event)
         self.harness.container_pebble_ready(container_name="nrf")
@@ -228,7 +232,7 @@ class TestCharm(unittest.TestCase):
             StringIO(self._read_file("tests/unit/expected_config/config.conf").strip()),
         ]
         patch_exists.side_effect = [True, False, True]
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready(container_name="nrf")
         patch_push.assert_not_called()
 
@@ -249,7 +253,7 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
 
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.container_pebble_ready(container_name="nrf")
@@ -292,7 +296,7 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
 
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.container_pebble_ready("nrf")
@@ -316,7 +320,7 @@ class TestCharm(unittest.TestCase):
         )
         patch_exists.return_value = True
 
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.container_pebble_ready(container_name="nrf")
@@ -340,7 +344,7 @@ class TestCharm(unittest.TestCase):
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
 
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.set_can_connect(container="nrf", val=True)
@@ -388,7 +392,7 @@ class TestCharm(unittest.TestCase):
             relation_id=relation_2_id, remote_unit_name="nrf-requirer-2/0"
         )
 
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.container_pebble_ready("nrf")
@@ -440,7 +444,7 @@ class TestCharm(unittest.TestCase):
     ):
         patch_exists.return_value = True
         self.harness.set_can_connect(container="nrf", val=True)
-        self._database_is_available()
+        self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.charm._on_certificates_relation_broken(event=Mock())
         self.assertEqual(


### PR DESCRIPTION
# Description

This PR aims to fix #48 . When database relation is removed, move into Blocked status.
As agreed, integration tests are not executed until canonical/mongodb-k8s-operator#218 will be fixed.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
