### PR TITLE
chore: Fix unit test for database relation broken

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -429,7 +429,9 @@ class TestCharm(unittest.TestCase):
 
         with self.assertRaises(FileNotFoundError):
             (root / "support/TLS/nrf.key").read_text()
+        with self.assertRaises(FileNotFoundError):
             (root / "support/TLS/nrf.pem").read_text()
+        with self.assertRaises(FileNotFoundError):
             (root / "support/TLS/nrf.csr").read_text()
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_status_is_blocked(  # noqa: E501


### PR DESCRIPTION
# Description

This PR aims to fix a wrong validation inside a unit test. The assertion on private key, certificate and signing request removal after database relation broken event should be performed for each single file and not in bulk.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
