### PR TITLE
chore: Removing --trust flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Charmed Operator for the SD-Core Network Repository Function (NRF).
 # Usage
 
 ```bash
-juju deploy sdcore-nrf --trust --channel=edge
+juju deploy sdcore-nrf --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy self-signed-certificates --channel=beta
 


### PR DESCRIPTION
# Description

Removes the `--trust` flag. After replacing `KubernetesServicePatch` with `ops.set_ports` it's not needed anymore.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
