### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-nrf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-nrf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-nrf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-nrf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
   lib-needs-publishing:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           filters: |
             fiveg_nrf:
-              - 'lib/charms/sdcore_nrf/v0/fiveg_nrf.py'
+              - 'lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py'
 
   publish-lib:
     name: Publish Lib
@@ -63,5 +63,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }} && ${{ needs.changes.outputs.needs-publishing == 'true' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-lib.yaml@main
     with:
-      lib-name: "charms.sdcore_nrf.v0.fiveg_nrf"
+      lib-name: "charms.sdcore_nrf_k8s.v0.fiveg_nrf"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core NRF Operator for K8s
+# SD-Core NRF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-nrf-k8s/badge.svg)](https://charmhub.io/sdcore-nrf-k8s)
 
 Charmed Operator for the SD-Core Network Repository Function (NRF) for K8s.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core NRF K8s Operator
+# SD-Core NRF Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-nrf-k8s/badge.svg)](https://charmhub.io/sdcore-nrf-k8s)
 
-Charmed K8s Operator for the SD-Core Network Repository Function (NRF).
+Charmed Operator for the SD-Core Network Repository Function (NRF) for K8s.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# SD-Core NRF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-nrf/badge.svg)](https://charmhub.io/sdcore-nrf)
+# SD-Core NRF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-nrf-k8s/badge.svg)](https://charmhub.io/sdcore-nrf-k8s)
 
-Charmed Operator for the SD-Core Network Repository Function (NRF).
+Charmed K8s Operator for the SD-Core Network Repository Function (NRF).
 
 # Usage
 
 ```bash
-juju deploy sdcore-nrf --channel=edge
+juju deploy sdcore-nrf-k8s --channel=edge
 juju deploy mongodb-k8s --trust --channel=5/edge
 juju deploy self-signed-certificates --channel=beta
 
-juju integrate sdcore-nrf:database mongodb-k8s
-juju integrate self-signed-certificates:certificates sdcore-nrf:certificates
+juju integrate sdcore-nrf-k8s:database mongodb-k8s
+juju integrate self-signed-certificates:certificates sdcore-nrf-k8s:certificates
 ```
 
 # Image

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,10 +1,10 @@
-name: sdcore-nrf
-display-name: SD-Core NRF
+name: sdcore-nrf-k8s
+display-name: SD-Core NRF K8s
 summary: Charmed Operator for the SD-Core Network Repository Function (NRF).
 description: Charmed Operator for the SD-Core Network Repository Function (NRF).
-website: https://charmhub.io/sdcore-nrf
-source: https://github.com/canonical/sdcore-nrf-operator
-issues: https://github.com/canonical/sdcore-nrf-operator/issues
+website: https://charmhub.io/sdcore-nrf-k8s
+source: https://github.com/canonical/sdcore-nrf-k8s-operator
+issues: https://github.com/canonical/sdcore-nrf-k8s-operator/issues
 
 containers:
   nrf:

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the SD-Core NRF service."""
+"""Charmed operator for the SD-Core NRF service for K8s."""
 
 import logging
 from ipaddress import IPv4Address
@@ -80,8 +80,8 @@ def _render_config(
     return content
 
 
-class NRFK8sOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core NRF K8s operator."""
+class NRFOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core NRF operator for K8s."""
 
     def __init__(self, *args):
         """Initialize charm."""
@@ -483,4 +483,4 @@ class NRFK8sOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(NRFK8sOperatorCharm)
+    main(NRFOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the SD-Core NRF service."""
+"""Charmed K8s operator for the SD-Core NRF service."""
 
 import logging
 from ipaddress import IPv4Address
@@ -80,8 +80,8 @@ def _render_config(
     return content
 
 
-class NRFOperatorCharm(CharmBase):
-    """Main class to describe juju event handling for the SD-Core NRF operator."""
+class NRFK8sOperatorCharm(CharmBase):
+    """Main class to describe juju event handling for the SD-Core NRF K8s operator."""
 
     def __init__(self, *args):
         """Initialize charm."""
@@ -483,4 +483,4 @@ class NRFOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(NRFOperatorCharm)
+    main(NRFK8sOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ from subprocess import check_output
 from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # type: ignore[import]
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju>=3.1
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/unit/charms/sdcore_nrf/v0/dummy_provider_charm/src/dummy_provider_charm.py
+++ b/tests/unit/charms/sdcore_nrf/v0/dummy_provider_charm/src/dummy_provider_charm.py
@@ -8,7 +8,7 @@
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from lib.charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):

--- a/tests/unit/charms/sdcore_nrf/v0/dummy_requirer_charm/src/dummy_requirer_charm.py
+++ b/tests/unit/charms/sdcore_nrf/v0/dummy_requirer_charm/src/dummy_requirer_charm.py
@@ -10,7 +10,7 @@ import logging
 from ops.charm import CharmBase
 from ops.main import main
 
-from lib.charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFBrokenEvent, NRFRequires
+from lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFBrokenEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
@@ -84,7 +84,7 @@ class TestFiveGNRFRequirer(unittest.TestCase):
                 relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
             )
             self.assertIn(
-                f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
+                f"DEBUG:lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf:Invalid relation data: {relation_data}",  # noqa: E501
                 log.output,
             )
 
@@ -116,7 +116,7 @@ class TestFiveGNRFRequirer(unittest.TestCase):
             nrf_url = self.harness.charm.nrf_requirer.nrf_url
             self.assertIsNone(nrf_url)
             self.assertIn(
-                f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
+                f"DEBUG:lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf:Invalid relation data: {relation_data}",  # noqa: E501
                 log.output,
             )
 
@@ -133,11 +133,11 @@ class TestFiveGNRFRequirer(unittest.TestCase):
             nrf_url = self.harness.charm.nrf_requirer.nrf_url
             self.assertIsNone(nrf_url)
             self.assertIn(
-                f"DEBUG:lib.charms.sdcore_nrf.v0.fiveg_nrf:Invalid relation data: {relation_data}",
+                f"DEBUG:lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf:Invalid relation data: {relation_data}",  # noqa: E501
                 log.output,
             )
 
-    @patch("lib.charms.sdcore_nrf.v0.fiveg_nrf.NRFRequirerCharmEvents.nrf_broken")
+    @patch("lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequirerCharmEvents.nrf_broken")
     def test_given_nrf_relation_created_when_relation_broken_then_nrf_broken_event_emitted(
         self, patched_nrf_broken_event
     ):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import NRFOperatorCharm  # type: ignore[import]
+from charm import NRFK8sOperatorCharm  # type: ignore[import]
 
 DB_APPLICATION_NAME = "mongodb-k8s"
 BASE_CONFIG_PATH = "/etc/nrf"
@@ -18,7 +18,7 @@ TLS_RELATION_NAME = "certificates"
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.harness = testing.Harness(NRFOperatorCharm)
+        self.harness = testing.Harness(NRFK8sOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import NRFK8sOperatorCharm  # type: ignore[import]
+from charm import NRFOperatorCharm  # type: ignore[import]
 
 DB_APPLICATION_NAME = "mongodb-k8s"
 BASE_CONFIG_PATH = "/etc/nrf"
@@ -18,7 +18,7 @@ TLS_RELATION_NAME = "certificates"
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.harness = testing.Harness(NRFK8sOperatorCharm)
+        self.harness = testing.Harness(NRFOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = lint, static, unit
 src_path = {toxinidir}/src/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-lib_path = {toxinidir}/lib/charms/sdcore_nrf/v0/
+lib_path = {toxinidir}/lib/charms/sdcore_nrf_k8s/v0/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Create new fiveg_nrf library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
